### PR TITLE
HCP Migration of Workspaces in PulsePixel/DataEcho repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,10 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+**/.terraform/*
+.terraform.lock.*
+*.tfstate
+*.tfstate.*
+_hcp-migrate-configs/
+!_hcp-migrate-configs/terraform.tfstate*

--- a/EchoStream/terraform.tf
+++ b/EchoStream/terraform.tf
@@ -7,9 +7,11 @@ terraform {
     }
   }
 
-  backend "s3" {
-    bucket = "dataecho"
-    key    = "terraform/state/dataecho/echostream/main.tfstate"
-    region = "us-west-1"
+  cloud {
+    organization = "PulsePixel"
+    workspaces {
+      project = "echo_stream"
+      name    = "echo_stream_default"
+    }
   }
 }

--- a/StreamMonitor/terraform.tf
+++ b/StreamMonitor/terraform.tf
@@ -7,9 +7,11 @@ terraform {
     }
   }
 
-  backend "s3" {
-    bucket = "dataecho"
-    key    = "terraform/state/dataecho/stream-monitor/main.tfstate"
-    region = "us-west-1"
+  cloud {
+    organization = "PulsePixel"
+    workspaces {
+      project = "stream_monitor"
+      tags    = ["stream_monitor"]
+    }
   }
 }

--- a/_hcp-migrate-configs/terraform.tfstate
+++ b/_hcp-migrate-configs/terraform.tfstate
@@ -1,0 +1,446 @@
+{
+  "version": 4,
+  "terraform_version": "1.9.2",
+  "serial": 14,
+  "lineage": "280f74ea-8bd7-b6a1-4121-7d4e9aed8674",
+  "outputs": {
+    "count_dir_skipped": {
+      "value": 0,
+      "type": "number"
+    },
+    "list_of_new_project_ids": {
+      "value": [
+        "prj-a9KEEfw5WPiB63aB",
+        "prj-PG3a6pgXwsZNEe6Z"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string",
+          "string"
+        ]
+      ]
+    },
+    "list_of_new_project_names": {
+      "value": [
+        "echo_stream",
+        "stream_monitor"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string",
+          "string"
+        ]
+      ]
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "tfe_project",
+      "name": "list_of_new_projects",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "echo_stream",
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: PulsePixel/DataEcho",
+            "id": "prj-a9KEEfw5WPiB63aB",
+            "name": "echo_stream",
+            "organization": "PulsePixel"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "stream_monitor",
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: PulsePixel/DataEcho",
+            "id": "prj-PG3a6pgXwsZNEe6Z",
+            "name": "stream_monitor",
+            "organization": "PulsePixel"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"EchoStream\"]",
+      "mode": "data",
+      "type": "tfe_project",
+      "name": "project",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: PulsePixel/DataEcho",
+            "id": "prj-a9KEEfw5WPiB63aB",
+            "name": "echo_stream",
+            "organization": "PulsePixel",
+            "workspace_ids": []
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"EchoStream\"]",
+      "mode": "managed",
+      "type": "tfe_workspace",
+      "name": "workspaces",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 1,
+          "attributes": {
+            "agent_pool_id": "",
+            "allow_destroy_plan": true,
+            "assessments_enabled": false,
+            "auto_apply": false,
+            "auto_apply_run_trigger": false,
+            "description": "",
+            "execution_mode": "remote",
+            "file_triggers_enabled": true,
+            "force_delete": false,
+            "global_remote_state": false,
+            "html_url": "https://app.terraform.io/app/PulsePixel/workspaces/echo_stream_default",
+            "id": "ws-phhnxtXdwfB2qqc7",
+            "ignore_additional_tag_names": null,
+            "name": "echo_stream_default",
+            "operations": true,
+            "organization": "PulsePixel",
+            "project_id": "prj-a9KEEfw5WPiB63aB",
+            "queue_all_runs": false,
+            "remote_state_consumer_ids": [],
+            "resource_count": 0,
+            "source_name": "",
+            "source_url": "",
+            "speculative_enabled": true,
+            "ssh_key_id": "",
+            "structured_run_output_enabled": true,
+            "tag_names": [
+              "echo_stream"
+            ],
+            "terraform_version": "1.9.2",
+            "trigger_patterns": null,
+            "trigger_prefixes": null,
+            "vcs_repo": [],
+            "working_directory": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"EchoStream\"]",
+      "mode": "managed",
+      "type": "tfmigrate_state_migration",
+      "name": "state-migration",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/DataEcho/EchoStream",
+            "local_workspace": "default",
+            "org": "PulsePixel",
+            "tfc_workspace": "echo_stream_default"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"EchoStream\"]",
+      "mode": "managed",
+      "type": "tfmigrate_terraform_init",
+      "name": "terraform_init",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/DataEcho/EchoStream",
+            "summary": "Terraform Init Completed."
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"EchoStream\"]",
+      "mode": "managed",
+      "type": "tfmigrate_update_backend",
+      "name": "update-backend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "backend_file_name": "terraform.tf",
+            "directory_path": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/DataEcho/EchoStream",
+            "id": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/DataEcho/EchoStream",
+            "org": "PulsePixel",
+            "project": "echo_stream",
+            "tags": [
+              "echo_stream"
+            ],
+            "workspace_map": {
+              "default": "echo_stream_default"
+            }
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_state_migration.state-migration",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"StreamMonitor\"]",
+      "mode": "data",
+      "type": "tfe_project",
+      "name": "project",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: PulsePixel/DataEcho",
+            "id": "prj-PG3a6pgXwsZNEe6Z",
+            "name": "stream_monitor",
+            "organization": "PulsePixel",
+            "workspace_ids": []
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"StreamMonitor\"]",
+      "mode": "managed",
+      "type": "tfe_workspace",
+      "name": "workspaces",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 1,
+          "attributes": {
+            "agent_pool_id": "",
+            "allow_destroy_plan": true,
+            "assessments_enabled": false,
+            "auto_apply": false,
+            "auto_apply_run_trigger": false,
+            "description": "",
+            "execution_mode": "remote",
+            "file_triggers_enabled": true,
+            "force_delete": false,
+            "global_remote_state": false,
+            "html_url": "https://app.terraform.io/app/PulsePixel/workspaces/stream_monitor_default",
+            "id": "ws-kn5euXqjbtFqTwVh",
+            "ignore_additional_tag_names": null,
+            "name": "stream_monitor_default",
+            "operations": true,
+            "organization": "PulsePixel",
+            "project_id": "prj-PG3a6pgXwsZNEe6Z",
+            "queue_all_runs": false,
+            "remote_state_consumer_ids": [],
+            "resource_count": 0,
+            "source_name": "",
+            "source_url": "",
+            "speculative_enabled": true,
+            "ssh_key_id": "",
+            "structured_run_output_enabled": true,
+            "tag_names": [
+              "stream_monitor"
+            ],
+            "terraform_version": "1.9.2",
+            "trigger_patterns": null,
+            "trigger_prefixes": null,
+            "vcs_repo": [],
+            "working_directory": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "tfe_project.list_of_new_projects"
+          ]
+        },
+        {
+          "index_key": "ops",
+          "schema_version": 1,
+          "attributes": {
+            "agent_pool_id": "",
+            "allow_destroy_plan": true,
+            "assessments_enabled": false,
+            "auto_apply": false,
+            "auto_apply_run_trigger": false,
+            "description": "",
+            "execution_mode": "remote",
+            "file_triggers_enabled": true,
+            "force_delete": false,
+            "global_remote_state": false,
+            "html_url": "https://app.terraform.io/app/PulsePixel/workspaces/stream_monitor_ops",
+            "id": "ws-4oKYJFPJHiBfi5RB",
+            "ignore_additional_tag_names": null,
+            "name": "stream_monitor_ops",
+            "operations": true,
+            "organization": "PulsePixel",
+            "project_id": "prj-PG3a6pgXwsZNEe6Z",
+            "queue_all_runs": false,
+            "remote_state_consumer_ids": [],
+            "resource_count": 0,
+            "source_name": "",
+            "source_url": "",
+            "speculative_enabled": true,
+            "ssh_key_id": "",
+            "structured_run_output_enabled": true,
+            "tag_names": [
+              "stream_monitor"
+            ],
+            "terraform_version": "1.9.2",
+            "trigger_patterns": null,
+            "trigger_prefixes": null,
+            "vcs_repo": [],
+            "working_directory": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"StreamMonitor\"]",
+      "mode": "managed",
+      "type": "tfmigrate_state_migration",
+      "name": "state-migration",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/DataEcho/StreamMonitor",
+            "local_workspace": "default",
+            "org": "PulsePixel",
+            "tfc_workspace": "stream_monitor_default"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        },
+        {
+          "index_key": "ops",
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/DataEcho/StreamMonitor",
+            "local_workspace": "ops",
+            "org": "PulsePixel",
+            "tfc_workspace": "stream_monitor_ops"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"StreamMonitor\"]",
+      "mode": "managed",
+      "type": "tfmigrate_terraform_init",
+      "name": "terraform_init",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/DataEcho/StreamMonitor",
+            "summary": "Terraform Init Completed."
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"StreamMonitor\"]",
+      "mode": "managed",
+      "type": "tfmigrate_update_backend",
+      "name": "update-backend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "backend_file_name": "terraform.tf",
+            "directory_path": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/DataEcho/StreamMonitor",
+            "id": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/DataEcho/StreamMonitor",
+            "org": "PulsePixel",
+            "project": "stream_monitor",
+            "tags": [
+              "stream_monitor"
+            ],
+            "workspace_map": {
+              "default": "stream_monitor_default",
+              "ops": "stream_monitor_ops"
+            }
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_state_migration.state-migration",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}


### PR DESCRIPTION
This PR is created by TFMigrate CLI to migrate the Workspaces from the repository PulsePixel/DataEcho to the HCP Workspace.